### PR TITLE
Modifications needed for the new NAS deployment

### DIFF
--- a/files/restic_backup.sh
+++ b/files/restic_backup.sh
@@ -35,6 +35,8 @@ if test -z "${REPO}" || test -z "${SOURCE}" ; then
   exit 1
 fi
 
+PATH="/usr/local/bin:$PATH" # Add restic cmd dir to path (if not set in crontab)
+
 echo Test if the repo exists
 restic --json -r "$REPO" snapshots --last > /dev/null
 rc=$?

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,7 @@ class restic(
     checksum_type   => $checksum_type,
     cleanup         => true,
     creates         => '/usr/local/bin/restic',
+    require         => Package['bzip2']
   }
   -> file { '/usr/local/bin/restic':
     ensure => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@ class restic(
     checksum_type   => $checksum_type,
     cleanup         => true,
     creates         => '/usr/local/bin/restic',
-    require         => Package['bzip2']
+    require         => Package['bzip2'],
   }
   -> file { '/usr/local/bin/restic':
     ensure => file,


### PR DESCRIPTION
Add restic folder in PATH, because the script fail with command not found if its not set by an other module.

Add a dependency to have bzip2 package before unarchiving the restic bin.