### PR TITLE
Change files cleanup in backup script

### DIFF
--- a/files/restic_backup.sh
+++ b/files/restic_backup.sh
@@ -58,7 +58,8 @@ fi
 PATH="/usr/local/bin:$PATH" # Add restic cmd dir to path (if not set in crontab)
 
 if [ "$TEXTFILE_COLLECTOR" = true ] ; then
-  rm $TEXTFILE_COLLECTOR_DIR/restic-snapshot* # clean up old textfiles
+  # clean up old textfile
+  rm "$TEXTFILE_COLLECTOR_DIR/restic-snapshot$(echo $SOURCE | tr '/' '_' | tr ' ' '+').prom"
 fi
 
 echo

--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -30,8 +30,8 @@ define restic::backup (
   $environment   = [],
 ) {
   cron { $title:
-    command     => "/usr/local/bin/restic_backup.sh -r ${repo} -s '${files}' -f '${forget_flags}' -b '${backup_flags}' ${textfile_flag} >> /var/log/restic/${title}.log",
     ensure      => $ensure,
+    command     => "/usr/local/bin/restic_backup.sh -r ${repo} -s '${files}' -f '${forget_flags}' -b '${backup_flags}' ${textfile_flag} >> /var/log/restic/${title}.log",
     user        => $cron_user,
     weekday     => $cron_day,
     hour        => $cron_hour,


### PR DESCRIPTION
Remove only the textfile corresponding to the source in cas of multiple restic jobs.
