### PR TITLE
fix: no restic metrics when backup failed

### DIFF
--- a/files/restic_backup.sh
+++ b/files/restic_backup.sh
@@ -93,6 +93,16 @@ output=$(restic $COMMAND_ARGS --json -r "$REPO" backup $SOURCE $BACKUP_ARGS)
 rc=$?
 log "$output"
 
+if [ $rc -ne 0 ]; then
+    read -r -d '' data <<EOF
+# HELP restic_backup_return_code Return code of restic backup command
+# TYPE restic_backup_return_code gauge
+restic_backup_return_code{repo="$REPO",source="$SOURCE"} $rc
+EOF
+    push_metrics "$data" "POST"
+    exit 1
+fi
+
 summary=$(echo "$output"|jq -s 'map(select(.message_type == "summary"))[0]')
 
 read -r -d '' data<<EOF


### PR DESCRIPTION
The restic metrics are not written when the restic backup command failed.
The json output `{"message_type":"status","percent_done":0}` does not contains the `summary` field. The result is that we have `null` value for some metrics and node_exporter failed to collect data from the generated textfile.

We want to have at least the restic_backup_return_code metric in order to be aware of failed backups.