### PR TITLE
fix backup.sh file permission and update some check logic

### DIFF
--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -56,6 +56,7 @@ define restic::backup (
   Hash[String,String]  $environment    = {},
 ) {
   file { "${restic::bin_path}/backup.sh":
+    mode    => '0755',
     content => stdlib::deferrable_epp("${module_name}/backup.sh.epp",
       {
         'repo'          => $repo,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "camptocamp-restic",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Camptocamp",
   "summary": "",
   "license": "Apache-2.0",

--- a/templates/backup.sh.epp
+++ b/templates/backup.sh.epp
@@ -1,4 +1,4 @@
 <% $environment.each |$k,$v| { -%>
-<%= $k %>='<%= $v %>'
+export <%= $k %>='<%= $v %>'
 <% } %>
 /usr/local/bin/restic_backup.sh -r '<%= $repo %>' -s "<%= $files %>" -f "<%= $forget_flags %>" -c "<%= $command_flags %>" -b "<%= $backup_flags %>" <%= $textfile_flag %> >> /var/log/restic/<%= $title %>.log


### PR DESCRIPTION
This PR:

- fix backup.sh file permission so that cronjob can launch it
- update the check logic before launching the backup: old check use snapshots --last, which is deprecated now, now using the check command
- add more logic: test if the repo locked, if the password is uncorrect